### PR TITLE
Resolve deprecation of is_ajax on WSGIRequest object

### DIFF
--- a/autocomplete_all/autocomplete_all.py
+++ b/autocomplete_all/autocomplete_all.py
@@ -9,6 +9,12 @@ if not settings.configured:
     settings.configure()   # required for docs: make html
 
 
+def is_ajax(request):
+    if hasattr(request, 'is_ajax'):
+        return request.is_ajax
+    return request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'
+
+
 # this mixin was added in 0.3 because it could fix problems with missing autocomplete widget in some scenario(s)
 class AutocompleteAllMixin:
     # here we use files distributed inside django 2+
@@ -65,7 +71,7 @@ class ModelAdmin(admin.ModelAdmin, AutocompleteAllMixin):
 
     def get_search_results(self, request, queryset, search_term):
         queryset, use_distinct = super().get_search_results(request, queryset, search_term)
-        if request.is_ajax and '/autocomplete/' in request.path:
+        if is_ajax(request) and '/autocomplete/' in request.path:
             strip_begin = reverse('admin:index')
             url = urllib.parse.urlparse(request.headers['Referer'])
             referer = url.path                    # example: /admin/friends/friend/add, /admin/friends/friend/36/change


### PR DESCRIPTION
Use the solution provided in [3.1 release notes](https://docs.djangoproject.com/en/3.1/releases/3.1/#id2)

> If you are writing your own AJAX detection method, request.is_ajax() can be reproduced exactly as request.headers.get('x-requested-with') == 'XMLHttpRequest'.

Fixes #5 